### PR TITLE
Make HTML string splitting efficient using partition

### DIFF
--- a/pelican/plugins/pandoc_reader/pandoc_reader.py
+++ b/pelican/plugins/pandoc_reader/pandoc_reader.py
@@ -263,12 +263,19 @@ class PandocReader(BaseReader):
     @staticmethod
     def _extract_contents(html_output, table_of_contents):
         """Extract body html, table of contents and metadata from output."""
+        # Extract pandoc metadata from html output
+        pandoc_json_metadata, _, html_output = html_output.partition("\n")
+
+        # Convert JSON string to dict
+        pandoc_metadata = json.loads(pandoc_json_metadata)
+
+        # Parse HTML output
         soup = bs4.BeautifulSoup(html_output, "html.parser")
 
-        # Get table of contents if one was requested
+        # Extract the table of contents if one was requested
         toc = ""
         if table_of_contents:
-            # Extract the table of contents
+            # Find the table of contents
             toc = soup.body.find("nav", id="TOC")
 
             if toc:
@@ -284,13 +291,10 @@ class PandocReader(BaseReader):
         # Remove body tag around html output
         soup.body.unwrap()
 
-        # Remove the metadata JSON string at the end of the HTML body
-        body = "".join(str(soup).strip().splitlines()[:-1])
+        # Strip leading and trailing spaces
+        html_output = str(soup).strip()
 
-        # Retrieve metadata string and convert to dict
-        pandoc_metadata = json.loads(html_output.splitlines()[-1])
-
-        return body, toc, pandoc_metadata
+        return html_output, toc, pandoc_metadata
 
     @staticmethod
     def _check_if_citations(arguments, extensions):

--- a/pelican/plugins/pandoc_reader/templates/pandoc-reader-default.html
+++ b/pelican/plugins/pandoc_reader/templates/pandoc-reader-default.html
@@ -1,3 +1,4 @@
+$meta-json$
 <body>
 $if(toc)$
 <nav id="$idprefix$TOC" role="doc-toc">
@@ -12,4 +13,3 @@ $for(include-after)$
 $include-after$
 $endfor$
 </body>
-$meta-json$

--- a/pelican/plugins/pandoc_reader/test_cases_with_valid_arg_citations.py
+++ b/pelican/plugins/pandoc_reader/test_cases_with_valid_arg_citations.py
@@ -39,7 +39,7 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
 
         self.assertEqual(
             (
-                '<h2 id="string-theory">String Theory</h2>'
+                '<h2 id="string-theory">String Theory</h2>\n'
                 "<p>But this foundational principle of science has"
                 " now been called into question by"
                 ' <a href="https://www.britannica.com/science/'
@@ -53,12 +53,12 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 " notwithstanding, is an issue that is still up for debate"
                 " <span"
                 ' class="citation" data-cites="siegel2015 castelvecchi2016'
-                ' alves2017 francis2019">[4]–[7]</span>.</p>'
-                '<h1 class="unnumbered" id="bibliography">References</h1>'
+                ' alves2017 francis2019">[4]–[7]</span>.</p>\n'
+                '<h1 class="unnumbered" id="bibliography">References</h1>\n'
                 '<div class="references csl-bib-body" id="refs"'
-                ' role="doc-bibliography">'
+                ' role="doc-bibliography">\n'
                 '<div class="csl-entry" id="ref-mann2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[1]'
                 ' </div><div class="csl-right-inline">A. Mann,'
                 " <span>“<span>What Is String Theory?</span>”</span>"
@@ -67,10 +67,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 '65033-what-is-string-theory.html">'
                 "https://www.livescience.com/"
                 "65033-what-is-string-theory.html</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-wood2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[2] </div>'
                 '<div class="csl-right-inline">'
                 "C. Wood, <span>“<span>What Is String Theory?</span>."
@@ -80,10 +80,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 ' [Online]. Available: <a href="https://www.space.com/'
                 '17594-string-theory.html">'
                 "https://www.space.com/17594-string-theory.html</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-jones2020"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[3]'
                 ' </div><div class="csl-right-inline">'
                 'A. Z. Jones, <span>“<span class="nocase">The Basics of String'
@@ -91,10 +91,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 ' <a href="https://www.thoughtco.com/'
                 'what-is-string-theory-2699363">'
                 "https://www.thoughtco.com/what-is-string-theory-2699363</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-siegel2015"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[4]'
                 ' </div><div class="csl-right-inline">'
                 "E. Siegel, <span>“<span>Why String Theory Is Not A Scientific"
@@ -105,10 +105,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 'why-string-theory-is-not-science/">https://www.forbes.com/'
                 "sites/startswithabang/2015/12/23/"
                 "why-string-theory-is-not-science/</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-castelvecchi2016"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[5]'
                 ' </div><div class="csl-right-inline">'
                 'D. Castelvecchi, <span>“<span class="nocase">'
@@ -120,10 +120,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 'feuding-physicists-turn-to-philosophy-for-help-1.19076">'
                 "https://www.nature.com/news/"
                 "feuding-physicists-turn-to-philosophy-for-help-1.19076</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-alves2017"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[6] </div>'
                 '<div class="csl-right-inline">'
                 'R. A. Batista and J. Primack, <span>“<span class="nocase">'
@@ -134,10 +134,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 '30-is-string-theory-falsifiable">'
                 "https://metafact.io/factchecks/"
                 "30-is-string-theory-falsifiable</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-francis2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[7]'
                 ' </div><div class="csl-right-inline">'
                 'M. R. Francis, <span>“<span class="nocase">Falsifiability and'
@@ -147,8 +147,8 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 ' <a href="https://www.scientificamerican.com/'
                 'article/is-string-theory-science/">'
                 "https://www.scientificamerican.com/article/is-"
-                "string-theory-science/</a>. [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                "string-theory-science/</a>. [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 "</div>"
             ),
             output,
@@ -180,7 +180,7 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
 
         self.assertEqual(
             (
-                '<h2 id="string-theory">String Theory</h2>'
+                '<h2 id="string-theory">String Theory</h2>\n'
                 "<p>But this foundational principle of science has"
                 " now been called into question by"
                 ' <a href="https://www.britannica.com/science/'
@@ -194,12 +194,12 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 " notwithstanding, is an issue that is still up for debate"
                 " <span"
                 ' class="citation" data-cites="siegel2015 castelvecchi2016'
-                ' alves2017 francis2019">[4]–[7]</span>.</p>'
-                '<h1 class="unnumbered" id="bibliography">References</h1>'
+                ' alves2017 francis2019">[4]–[7]</span>.</p>\n'
+                '<h1 class="unnumbered" id="bibliography">References</h1>\n'
                 '<div class="references csl-bib-body" id="refs"'
-                ' role="doc-bibliography">'
+                ' role="doc-bibliography">\n'
                 '<div class="csl-entry" id="ref-mann2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[1]'
                 ' </div><div class="csl-right-inline">A. Mann,'
                 " <span>“<span>What Is String Theory?</span>”</span>"
@@ -208,10 +208,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 '65033-what-is-string-theory.html">'
                 "https://www.livescience.com/"
                 "65033-what-is-string-theory.html</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-wood2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[2] </div>'
                 '<div class="csl-right-inline">'
                 "C. Wood, <span>“<span>What Is String Theory?</span>."
@@ -221,10 +221,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 ' [Online]. Available: <a href="https://www.space.com/'
                 '17594-string-theory.html">'
                 "https://www.space.com/17594-string-theory.html</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-jones2020"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[3]'
                 ' </div><div class="csl-right-inline">'
                 'A. Z. Jones, <span>“<span class="nocase">The Basics of String'
@@ -232,10 +232,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 ' <a href="https://www.thoughtco.com/'
                 'what-is-string-theory-2699363">'
                 "https://www.thoughtco.com/what-is-string-theory-2699363</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-siegel2015"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[4]'
                 ' </div><div class="csl-right-inline">'
                 "E. Siegel, <span>“<span>Why String Theory Is Not A Scientific"
@@ -246,10 +246,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 'why-string-theory-is-not-science/">https://www.forbes.com/'
                 "sites/startswithabang/2015/12/23/"
                 "why-string-theory-is-not-science/</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-castelvecchi2016"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[5]'
                 ' </div><div class="csl-right-inline">'
                 'D. Castelvecchi, <span>“<span class="nocase">'
@@ -261,10 +261,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 'feuding-physicists-turn-to-philosophy-for-help-1.19076">'
                 "https://www.nature.com/news/"
                 "feuding-physicists-turn-to-philosophy-for-help-1.19076</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-alves2017"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[6] </div>'
                 '<div class="csl-right-inline">'
                 'R. A. Batista and J. Primack, <span>“<span class="nocase">'
@@ -275,10 +275,10 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 '30-is-string-theory-falsifiable">'
                 "https://metafact.io/factchecks/"
                 "30-is-string-theory-falsifiable</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-francis2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[7]'
                 ' </div><div class="csl-right-inline">'
                 'M. R. Francis, <span>“<span class="nocase">Falsifiability and'
@@ -288,8 +288,8 @@ class TestValidCaseWithArgumentsAndCitations(unittest.TestCase):
                 ' <a href="https://www.scientificamerican.com/'
                 'article/is-string-theory-science/">'
                 "https://www.scientificamerican.com/article/is-"
-                "string-theory-science/</a>. [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                "string-theory-science/</a>. [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 "</div>"
             ),
             output,

--- a/pelican/plugins/pandoc_reader/test_cases_with_valid_args.py
+++ b/pelican/plugins/pandoc_reader/test_cases_with_valid_args.py
@@ -52,8 +52,9 @@ class TestValidCasesWithArguments(unittest.TestCase):
 
         self.assertEqual(
             (
-                '<p><span class="math display">\\[e^{i\\theta} = '
-                "\\cos\\theta + i \\sin\\theta.\\]</span></p>"
+                '<p><span class="math display">\\[\n'
+                "e^{i\\theta} = \\cos\\theta + i \\sin\\theta.\n"
+                "\\]</span></p>"
             ),
             output,
         )
@@ -78,11 +79,11 @@ class TestValidCasesWithArguments(unittest.TestCase):
         self.assertEqual(
             (
                 "<p>This is some valid content that should pass."
-                " If it does not pass we will know something is wrong.</p>"
+                " If it does not pass we will know something is wrong.</p>\n"
                 "<p>Our fictitious internal files are available"
-                ' <a href="{filename}/path/to/file">at</a>:</p>'
+                ' <a href="{filename}/path/to/file">at</a>:</p>\n'
                 "<p>Our fictitious static files are available"
-                ' <a href="{static}/path/to/file">at</a>:</p>'
+                ' <a href="{static}/path/to/file">at</a>:</p>\n'
                 "<p>Our fictitious attachments are available"
                 ' <a href="{attach}path/to/file">at</a>:</p>'
             ),
@@ -95,7 +96,7 @@ class TestValidCasesWithArguments(unittest.TestCase):
         self.assertEqual("My Author", str(metadata["author"]))
         self.assertEqual("2020-10-16 00:00:00", str(metadata["date"]))
 
-    def test_valid_content_with_toc(self):
+    def test_valid_content_with_toc_1(self):
         """Check if output returned is valid and table of contents is valid."""
         settings = get_settings(
             PANDOC_EXTENSIONS=PANDOC_EXTENSIONS, PANDOC_ARGS=PANDOC_ARGS + ["--toc"],
@@ -111,17 +112,17 @@ class TestValidCasesWithArguments(unittest.TestCase):
         self.assertEqual(
             (
                 "<p>This is some valid content that should pass."
-                " If it does not pass we will know something is wrong.</p>"
-                '<h2 id="first-heading">First Heading</h2>'
+                " If it does not pass we will know something is wrong.</p>\n"
+                '<h2 id="first-heading">First Heading</h2>\n'
                 "<p>This should be the first heading in my"
-                " table of contents.</p>"
-                '<h2 id="second-heading">Second Heading</h2>'
+                " table of contents.</p>\n"
+                '<h2 id="second-heading">Second Heading</h2>\n'
                 "<p>This should be the second heading in my"
-                " table of contents.</p>"
-                '<h3 id="first-subheading">First Subheading</h3>'
+                " table of contents.</p>\n"
+                '<h3 id="first-subheading">First Subheading</h3>\n'
                 "<p>This is a subsection that should be shown as such"
-                " in the table of contents.</p>"
-                '<h3 id="second-subheading">Second Subheading</h3>'
+                " in the table of contents.</p>\n"
+                '<h3 id="second-subheading">Second Subheading</h3>\n'
                 "<p>This is another subsection that should be shown as"
                 " such in the table of contents.</p>"
             ),
@@ -161,17 +162,17 @@ class TestValidCasesWithArguments(unittest.TestCase):
         self.assertEqual(
             (
                 "<p>This is some valid content that should pass."
-                " If it does not pass we will know something is wrong.</p>"
-                '<h2 id="first-heading">First Heading</h2>'
+                " If it does not pass we will know something is wrong.</p>\n"
+                '<h2 id="first-heading">First Heading</h2>\n'
                 "<p>This should be the first heading in my"
-                " table of contents.</p>"
-                '<h2 id="second-heading">Second Heading</h2>'
+                " table of contents.</p>\n"
+                '<h2 id="second-heading">Second Heading</h2>\n'
                 "<p>This should be the second heading in my"
-                " table of contents.</p>"
-                '<h3 id="first-subheading">First Subheading</h3>'
+                " table of contents.</p>\n"
+                '<h3 id="first-subheading">First Subheading</h3>\n'
                 "<p>This is a subsection that should be shown as such"
-                " in the table of contents.</p>"
-                '<h3 id="second-subheading">Second Subheading</h3>'
+                " in the table of contents.</p>\n"
+                '<h3 id="second-subheading">Second Subheading</h3>\n'
                 "<p>This is another subsection that should be shown as"
                 " such in the table of contents.</p>"
             ),

--- a/pelican/plugins/pandoc_reader/test_cases_with_valid_default_files.py
+++ b/pelican/plugins/pandoc_reader/test_cases_with_valid_default_files.py
@@ -54,8 +54,9 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
 
         self.assertEqual(
             (
-                '<p><span class="math display">\\[e^{i\\theta} = '
-                "\\cos\\theta + i \\sin\\theta.\\]</span></p>"
+                '<p><span class="math display">\\[\n'
+                "e^{i\\theta} = \\cos\\theta + i \\sin\\theta.\n"
+                "\\]</span></p>"
             ),
             output,
         )
@@ -80,17 +81,17 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
         self.assertEqual(
             (
                 "<p>This is some valid content that should pass."
-                " If it does not pass we will know something is wrong.</p>"
-                '<h2 id="first-heading">First Heading</h2>'
+                " If it does not pass we will know something is wrong.</p>\n"
+                '<h2 id="first-heading">First Heading</h2>\n'
                 "<p>This should be the first heading in my"
-                " table of contents.</p>"
-                '<h2 id="second-heading">Second Heading</h2>'
+                " table of contents.</p>\n"
+                '<h2 id="second-heading">Second Heading</h2>\n'
                 "<p>This should be the second heading in my"
-                " table of contents.</p>"
-                '<h3 id="first-subheading">First Subheading</h3>'
+                " table of contents.</p>\n"
+                '<h3 id="first-subheading">First Subheading</h3>\n'
                 "<p>This is a subsection that should be shown as such"
-                " in the table of contents.</p>"
-                '<h3 id="second-subheading">Second Subheading</h3>'
+                " in the table of contents.</p>\n"
+                '<h3 id="second-subheading">Second Subheading</h3>\n'
                 "<p>This is another subsection that should be shown as"
                 " such in the table of contents.</p>"
             ),
@@ -131,7 +132,7 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
 
         self.assertEqual(
             (
-                '<h2 id="string-theory">String Theory</h2>'
+                '<h2 id="string-theory">String Theory</h2>\n'
                 "<p>But this foundational principle of science has"
                 " now been called into question by"
                 ' <a href="https://www.britannica.com/science/'
@@ -145,12 +146,12 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 " notwithstanding, is an issue that is still up for debate"
                 " <span"
                 ' class="citation" data-cites="siegel2015 castelvecchi2016'
-                ' alves2017 francis2019">[4]–[7]</span>.</p>'
-                '<h1 class="unnumbered" id="bibliography">References</h1>'
+                ' alves2017 francis2019">[4]–[7]</span>.</p>\n'
+                '<h1 class="unnumbered" id="bibliography">References</h1>\n'
                 '<div class="references csl-bib-body" id="refs"'
-                ' role="doc-bibliography">'
+                ' role="doc-bibliography">\n'
                 '<div class="csl-entry" id="ref-mann2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[1]'
                 ' </div><div class="csl-right-inline">A. Mann,'
                 " <span>“<span>What Is String Theory?</span>”</span>"
@@ -159,10 +160,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 '65033-what-is-string-theory.html">'
                 "https://www.livescience.com/"
                 "65033-what-is-string-theory.html</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-wood2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[2] </div>'
                 '<div class="csl-right-inline">'
                 "C. Wood, <span>“<span>What Is String Theory?</span>."
@@ -172,10 +173,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 ' [Online]. Available: <a href="https://www.space.com/'
                 '17594-string-theory.html">'
                 "https://www.space.com/17594-string-theory.html</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-jones2020"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[3]'
                 ' </div><div class="csl-right-inline">'
                 'A. Z. Jones, <span>“<span class="nocase">The Basics of String'
@@ -183,10 +184,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 ' <a href="https://www.thoughtco.com/'
                 'what-is-string-theory-2699363">'
                 "https://www.thoughtco.com/what-is-string-theory-2699363</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-siegel2015"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[4]'
                 ' </div><div class="csl-right-inline">'
                 "E. Siegel, <span>“<span>Why String Theory Is Not A Scientific"
@@ -197,10 +198,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 'why-string-theory-is-not-science/">https://www.forbes.com/'
                 "sites/startswithabang/2015/12/23/"
                 "why-string-theory-is-not-science/</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-castelvecchi2016"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[5]'
                 ' </div><div class="csl-right-inline">'
                 'D. Castelvecchi, <span>“<span class="nocase">'
@@ -212,10 +213,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 'feuding-physicists-turn-to-philosophy-for-help-1.19076">'
                 "https://www.nature.com/news/"
                 "feuding-physicists-turn-to-philosophy-for-help-1.19076</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-alves2017"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[6] </div>'
                 '<div class="csl-right-inline">'
                 'R. A. Batista and J. Primack, <span>“<span class="nocase">'
@@ -226,10 +227,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 '30-is-string-theory-falsifiable">'
                 "https://metafact.io/factchecks/"
                 "30-is-string-theory-falsifiable</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-francis2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[7]'
                 ' </div><div class="csl-right-inline">'
                 'M. R. Francis, <span>“<span class="nocase">Falsifiability and'
@@ -239,8 +240,8 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 ' <a href="https://www.scientificamerican.com/'
                 'article/is-string-theory-science/">'
                 "https://www.scientificamerican.com/article/is-"
-                "string-theory-science/</a>. [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                "string-theory-science/</a>. [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 "</div>"
             ),
             output,
@@ -277,7 +278,7 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
 
         self.assertEqual(
             (
-                '<h2 id="string-theory">String Theory</h2>'
+                '<h2 id="string-theory">String Theory</h2>\n'
                 "<p>But this foundational principle of science has"
                 " now been called into question by"
                 ' <a href="https://www.britannica.com/science/'
@@ -291,12 +292,12 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 " notwithstanding, is an issue that is still up for debate"
                 " <span"
                 ' class="citation" data-cites="siegel2015 castelvecchi2016'
-                ' alves2017 francis2019">[4]–[7]</span>.</p>'
-                '<h1 class="unnumbered" id="bibliography">References</h1>'
+                ' alves2017 francis2019">[4]–[7]</span>.</p>\n'
+                '<h1 class="unnumbered" id="bibliography">References</h1>\n'
                 '<div class="references csl-bib-body" id="refs"'
-                ' role="doc-bibliography">'
+                ' role="doc-bibliography">\n'
                 '<div class="csl-entry" id="ref-mann2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[1]'
                 ' </div><div class="csl-right-inline">A. Mann,'
                 " <span>“<span>What Is String Theory?</span>”</span>"
@@ -305,10 +306,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 '65033-what-is-string-theory.html">'
                 "https://www.livescience.com/"
                 "65033-what-is-string-theory.html</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-wood2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[2] </div>'
                 '<div class="csl-right-inline">'
                 "C. Wood, <span>“<span>What Is String Theory?</span>."
@@ -318,10 +319,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 ' [Online]. Available: <a href="https://www.space.com/'
                 '17594-string-theory.html">'
                 "https://www.space.com/17594-string-theory.html</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-jones2020"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[3]'
                 ' </div><div class="csl-right-inline">'
                 'A. Z. Jones, <span>“<span class="nocase">The Basics of String'
@@ -329,10 +330,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 ' <a href="https://www.thoughtco.com/'
                 'what-is-string-theory-2699363">'
                 "https://www.thoughtco.com/what-is-string-theory-2699363</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-siegel2015"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[4]'
                 ' </div><div class="csl-right-inline">'
                 "E. Siegel, <span>“<span>Why String Theory Is Not A Scientific"
@@ -343,10 +344,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 'why-string-theory-is-not-science/">https://www.forbes.com/'
                 "sites/startswithabang/2015/12/23/"
                 "why-string-theory-is-not-science/</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-castelvecchi2016"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[5]'
                 ' </div><div class="csl-right-inline">'
                 'D. Castelvecchi, <span>“<span class="nocase">'
@@ -358,10 +359,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 'feuding-physicists-turn-to-philosophy-for-help-1.19076">'
                 "https://www.nature.com/news/"
                 "feuding-physicists-turn-to-philosophy-for-help-1.19076</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-alves2017"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[6] </div>'
                 '<div class="csl-right-inline">'
                 'R. A. Batista and J. Primack, <span>“<span class="nocase">'
@@ -372,10 +373,10 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 '30-is-string-theory-falsifiable">'
                 "https://metafact.io/factchecks/"
                 "30-is-string-theory-falsifiable</a>."
-                " [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                " [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 '<div class="csl-entry" id="ref-francis2019"'
-                ' role="doc-biblioentry">'
+                ' role="doc-biblioentry">\n'
                 '<div class="csl-left-margin">[7]'
                 ' </div><div class="csl-right-inline">'
                 'M. R. Francis, <span>“<span class="nocase">Falsifiability and'
@@ -385,8 +386,8 @@ class TestValidCasesWithDefaultFiles(unittest.TestCase):
                 ' <a href="https://www.scientificamerican.com/'
                 'article/is-string-theory-science/">'
                 "https://www.scientificamerican.com/article/is-"
-                "string-theory-science/</a>. [Accessed: 12-Nov-2020]</div>"
-                "</div>"
+                "string-theory-science/</a>. [Accessed: 12-Nov-2020]</div>\n"
+                "</div>\n"
                 "</div>"
             ),
             output,


### PR DESCRIPTION
Using string.partition() allowed me to extract the Pandoc metadata and HTML content in one go more efficiently than using string.splitstrings() which creates a new string for each element of the list.

This will speed up the processing when working with large files with many lines.