### PR TITLE
Use PDM & Ruff instead of Poetry+Black+Flake8+isort

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,0 +1,28 @@
+{
+  "template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
+  "commit": "8966a5d5f055ebfdeb0cf88758436eaf4cc62cd5",
+  "checkout": null,
+  "context": {
+    "cookiecutter": {
+      "plugin_name": "Pandoc Reader",
+      "repo_name": "pandoc-reader",
+      "package_name": "pandoc_reader",
+      "distribution_name": "pelican-pandoc-reader",
+      "version": "3.0.0",
+      "description": "Pelican plugin for converting Pandoc's Markdown variant to HTML.",
+      "authors": "{name = \"Nandakumar Chandrasekhar\", email = \"navanitachora@gmail.com\"}, {name = \"Justin Mayer\", email = \"entroP@gmail.com\"}",
+      "keywords": "\"pelican\", \"plugin\", \"markdown\", \"pandoc\"",
+      "readme": "README.md",
+      "contributing": "CONTRIBUTING.md",
+      "license": "GNU Affero General Public License v3|AGPL-3.0",
+      "repo_url": "https://github.com/pelican-plugins/pandoc-reader",
+      "dev_status": "5 - Production/Stable",
+      "tests_exist": true,
+      "python_version": "~=3.9",
+      "pelican_version": ">=4.5",
+      "_template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
+      "_commit": "8966a5d5f055ebfdeb0cf88758436eaf4cc62cd5"
+    }
+  },
+  "directory": null
+}

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-custom: https://donate.getpelican.com
+github: justinmayer
 liberapay: pelican

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,12 @@ on: [push, pull_request]
 env:
   PYTEST_ADDOPTS: "--color=yes"
 
-jobs:
+permissions:
+  contents: read
 
+jobs:
   test:
-    name: Test - ${{ matrix.python-version }}
+    name: Test - Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -16,47 +18,38 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }} & PDM
+        uses: pdm-project/setup-pdm@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up Pip cache
-        uses: actions/cache@v4
-        id: pip-cache
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ hashFiles('**/pyproject.toml') }}
-      - name: Upgrade Pip
-        run: python -m pip install --upgrade pip
-      - name: Install Poetry
-        run: python -m pip install poetry
-      - name: Set up Poetry cache
-        uses: actions/cache@v4
-        id: poetry-cache
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
+          cache: true
+          cache-dependency-path: ./pyproject.toml
+
       - name: Install dependencies
-        run: |
-          poetry run pip install --upgrade pip
-          poetry install
-      - name: Install supported pandoc 3.5
+        run: pdm install
+
+      - name: Install supported Pandoc 3.5
         run: |
           wget https://github.com/jgm/pandoc/releases/download/3.5/pandoc-3.5-1-amd64.deb
           sudo dpkg -i pandoc-3.5-1-amd64.deb
-      - name: Install unsupported pandoc 2.10
+
+      - name: Install unsupported Pandoc 2.10
         run: |
           wget https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           sudo mkdir 2.10
           sudo tar xvzf pandoc-2.10.1-linux-amd64.tar.gz --strip-components 1 -C 2.10
-      - name: Install unsupported pandoc 1.19
+
+      - name: Install unsupported Pandoc 1.19
         run: |
           wget https://github.com/jgm/pandoc/releases/download/1.19.2.1/pandoc-1.19.2.1-1-amd64.deb
           sudo mkdir 1.19
           sudo ar p pandoc-1.19.2.1-1-amd64.deb data.tar.gz | sudo tar xvz --strip-components 2 -C 1.19
-      - name: Run tests
-        run: poetry run invoke tests
 
+      - name: Run tests
+        run: pdm run invoke tests
 
   lint:
     name: Lint
@@ -64,62 +57,60 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate links in Markdown files
         uses: JustinBeckwith/linkinator-action@v1
         with:
           retry: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Python & PDM
+        uses: pdm-project/setup-pdm@v4
         with:
-          python-version: "3.9"
-
-      - name: Set Poetry cache
-        uses: actions/cache@v4
-        id: poetry-cache
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install Poetry
-        run: python -m pip install poetry
+          python-version: "3.10"
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: pdm install
 
       - name: Run linters
-        run: poetry run invoke lint --diff
+        run: pdm run invoke lint --diff
 
   deploy:
     name: Deploy
+    environment: Deployment
     needs: [test, lint]
     runs-on: ubuntu-latest
     if: github.ref=='refs/heads/main' && github.event_name!='pull_request'
 
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Check release
         id: check_release
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install poetry githubrelease httpx==0.18.2 autopub
-          echo "release=$(autopub check)" >> $GITHUB_OUTPUT
+          python -m pip install autopub[github]
+          autopub check
+
       - name: Publish
-        if: ${{ steps.check_release.outputs.release=='' }}
+        if: ${{ steps.check_release.outputs.autopub_release=='true' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git remote set-url origin https://$GITHUB_TOKEN@github.com/${{ github.repository }}
           autopub prepare
-          poetry build
           autopub commit
+          autopub build
           autopub githubrelease
-          poetry publish -u __token__ -p $PYPI_PASSWORD
+
+      - name: Upload package to PyPI
+        if: ${{ steps.check_release.outputs.autopub_release=='true' }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-poetry.lock
-Pipfile
-Pipfile.lock
+.pdm-python
+pdm.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,30 +20,9 @@ repos:
       - id: forbid-new-submodules
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.2
     hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-        args: [--max-line-length=88]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-
-  - repo: https://github.com/hakancelikdev/unimport
-    rev: 1.2.1
-    hooks:
-      - id: unimport
-        args: [--remove, --include-star-import]
+      - id: ruff-check
+      - id: ruff-format
+        args: ["--check"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Pandoc Reader: A Plugin for Pelican
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/pelican-plugins/pandoc-reader/main.yml?branch=main)](https://github.com/pelican-plugins/pandoc-reader/actions)
 [![PyPI Version](https://img.shields.io/pypi/v/pelican-pandoc-reader)](https://pypi.org/project/pelican-pandoc-reader/)
+[![Downloads](https://img.shields.io/pypi/dm/pelican-pandoc-reader)](https://pypi.org/project/pelican-pandoc-reader/)
 ![License](https://img.shields.io/pypi/l/pelican-pandoc-reader?color=blue)
 
 Pandoc Reader is a [Pelican][] plugin that converts documents written in [Pandoc’s variant of Markdown][] into HTML.
@@ -25,6 +26,8 @@ This plugin can be installed via:
 ```bash
 python -m pip install pelican-pandoc-reader
 ```
+
+As long as you have not explicitly added a `PLUGINS` setting to your Pelican settings file, then the newly-installed plugin should be automatically detected and enabled. Otherwise, you must add `pandoc_reader` to your existing `PLUGINS` list. For more information, please see the [How to Use Plugins](https://docs.getpelican.com/en/latest/plugins.html#how-to-use-plugins) documentation.
 
 Configuration
 -------------

--- a/pelican/plugins/pandoc_reader/__init__.py
+++ b/pelican/plugins/pandoc_reader/__init__.py
@@ -1,3 +1,3 @@
 """Importing pandoc_reader package."""
 
-from .pandoc_reader import *  # NOQA
+from .pandoc_reader import *  # noqa: F403,PGH004,RUF100

--- a/pelican/plugins/pandoc_reader/pandoc_reader.py
+++ b/pelican/plugins/pandoc_reader/pandoc_reader.py
@@ -184,11 +184,9 @@ class PandocReader(BaseReader):
             citeproc_specified = False
 
             # Cases where citeproc is specified as citeproc: true
-            if defaults.get("citeproc", ""):
-                citeproc_specified = True
-
-            # Cases where citeproc is specified in filters
-            elif "citeproc" in defaults.get("filters", ""):
+            if defaults.get("citeproc", "") or "citeproc" in defaults.get(
+                "filters", ""
+            ):
                 citeproc_specified = True
 
             # The extension +citations is enabled by default in Pandoc 2.11
@@ -230,7 +228,7 @@ class PandocReader(BaseReader):
             reading_time = math.ceil(float(wordcount) / float(reading_speed))
             if reading_time == 1:
                 time_unit = "minute"
-            reading_time = f"{str(reading_time)} {time_unit}"
+            reading_time = f"{reading_time!s} {time_unit}"
         except ValueError as words_per_minute_nan:
             raise ValueError(
                 "READING_SPEED setting must be a number."
@@ -312,9 +310,7 @@ class PandocReader(BaseReader):
         pandoc_cmd = [
             pandoc_executable,
             "--standalone",
-            "--template={}".format(
-                os.path.join(TEMPLATES_PATH, PANDOC_READER_HTML_TEMPLATE)
-            ),
+            f"--template={os.path.join(TEMPLATES_PATH, PANDOC_READER_HTML_TEMPLATE)}",
         ]
         if not defaults_files:
             pandoc_cmd.extend(["--from", "markdown" + extensions, "--to", "html5"])

--- a/pelican/plugins/pandoc_reader/test/test_invalid_multiple_defaults_files.py
+++ b/pelican/plugins/pandoc_reader/test/test_invalid_multiple_defaults_files.py
@@ -55,8 +55,7 @@ class TestInvalidCasesWithMultipleDefaultsFiles(unittest.TestCase):
 
         message = str(context_manager.exception)
         self.assertEqual(
-            "Specifying both to and writer is not supported."
-            " Please specify just one.",
+            "Specifying both to and writer is not supported. Please specify just one.",
             message,
         )
 

--- a/pelican/plugins/pandoc_reader/test/test_valid_args.py
+++ b/pelican/plugins/pandoc_reader/test/test_valid_args.py
@@ -81,7 +81,7 @@ class TestValidCasesWithArguments(unittest.TestCase):
         """Check if expected output is returned with --toc argument."""
         settings = get_settings(
             PANDOC_EXTENSIONS=PANDOC_EXTENSIONS,
-            PANDOC_ARGS=PANDOC_ARGS + ["--toc"],
+            PANDOC_ARGS=[*PANDOC_ARGS, "--toc"],
         )
 
         pandoc_reader = PandocReader(settings)
@@ -101,7 +101,7 @@ class TestValidCasesWithArguments(unittest.TestCase):
         """Check if expected output is returned with --table-of-contents argument."""
         settings = get_settings(
             PANDOC_EXTENSIONS=PANDOC_EXTENSIONS,
-            PANDOC_ARGS=PANDOC_ARGS + ["--table-of-contents"],
+            PANDOC_ARGS=[*PANDOC_ARGS, "--table-of-contents"],
         )
 
         pandoc_reader = PandocReader(settings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,57 +1,64 @@
-[tool.poetry]
+[project]
 name = "pelican-pandoc-reader"
 version = "3.0.0"
 description = "Pelican plugin for converting Pandoc's Markdown variant to HTML."
-authors = ["Nandakumar Chandrasekhar <navanitachora@gmail.com>"]
-license = "AGPL-3.0"
+authors = [{name = "Nandakumar Chandrasekhar", email = "navanitachora@gmail.com"}, {name = "Justin Mayer", email = "entroP@gmail.com"}]
+license = {text = "AGPL-3.0"}
 readme = "README.md"
 keywords = ["pelican", "plugin", "markdown", "pandoc"]
-repository = "https://github.com/pelican-plugins/pandoc-reader"
-documentation = "https://docs.getpelican.com"
-packages = [
-    { include = "pelican" },
-]
-
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Framework :: Pelican",
     "Framework :: Pelican :: Plugins",
     "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+requires-python = "~=3.9"
+dependencies = [
+    "pelican>=4.5",
+    "beautifulsoup4>=4.9.3",
+    "docutils>=0.21.2",
+    "markdown>=3.6",
+    "pyyaml>=6.0",
+    "ruamel.yaml>=0.17.32",
+]
 
-[tool.poetry.urls]
-"Funding" = "https://donate.getpelican.com/"
+[project.urls]
+"Homepage" = "https://github.com/pelican-plugins/pandoc-reader"
 "Issue Tracker" = "https://github.com/pelican-plugins/pandoc-reader/issues"
+"Changelog" = "https://github.com/pelican-plugins/pandoc-reader/blob/main/CHANGELOG.md"
+"Funding" = "https://donate.getpelican.com/"
 
-[tool.poetry.dependencies]
-python = ">=3.9.0,<4.0"
-pelican = ">=4.5"
-markdown = ">=3.6"
-pyyaml = "^6.0.0"
-beautifulsoup4 = "^4.9.3"
-"ruamel.yaml" = "^0.17.32"
-docutils = "^0.21.2"
+[dependency-groups]
+lint = [
+    "invoke>=2.2",
+    "ruff>=0.12.0,<1.0.0",
+]
+test = [
+    "invoke>=2.2",
+    "markdown>=3.6",
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "pytest-sugar>=1.0",
+]
 
-[tool.poetry.dev-dependencies]
-black = "^23"
-flake8 = "^4.0.1"
-flake8-black = "^0.2.0"
-invoke = "^2.0"
-isort = "^5.12.0"
-livereload = "^2.6"
-markdown = ">=3.6"
-pytest = "^6.0"
-pytest-cov = "^2.8"
-pytest-pythonpath = "^0.7.3"
-pytest-sugar = "^0.9.4"
-Werkzeug = "^1.0"
-
-[tool.poetry.extras]
-markdown = ["markdown"]
+[tool.pdm.build]
+source-includes = [
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+]
+includes = ["pelican/"]
+excludes = ["**/.DS_Store", "**/test_data/**", "tasks.py"]
 
 [tool.autopub]
 project-name = "Pandoc Reader"
@@ -59,20 +66,52 @@ git-username = "botpub"
 git-email = "52496925+botpub@users.noreply.github.com"
 append-github-contributor = true
 
-[tool.isort]
-# Maintain compatibility with Black
-profile = "black"
-multi_line_output = 3
+[tool.ruff.lint]
+select = [
+  "B",   # flake8-bugbear
+  "BLE", # flake8-blind-except
+  "C4",  # flake8-comprehensions
+  "D",   # pydocstyle
+  "E",   # pycodestyle
+  "F",   # pyflakes
+  "I",   # isort
+  "ICN", # flake8-import-conventions
+  "ISC", # flake8-implicit-str-concat
+  "PGH", # pygrep-hooks
+  "PL",  # pylint
+  "RET", # flake8-return
+  "RUF", # ruff-specific rules
+  "SIM", # flake8-simplify
+  "T10", # flake8-debugger
+  "T20", # flake8-print
+  "TID", # flake8-tidy-imports
+  "TRY", # tryceratops
+  "UP",  # pyupgrade
+  "W",   # pycodestyle
+  "YTT", # flake8-2020
+]
 
-# Sort imports within their section independent of the import type
-force_sort_within_sections = true
+ignore = [
+  "D100",    # missing docstring in public module
+  "D101",    # missing docstring in public class
+  "D104",    # missing docstring in public package
+  "D203",    # blank line before class docstring
+  "D213",    # multi-line docstring summary should start at the second line
+  "ISC001",  # disabled so `ruff format` works without warning
+  "PLW2901", # for loop variable overwritten by assignment target
+  "RUF005",  # use iterable unpacking instead of concatenation
+  "SIM102",  # nested `if` statements
+  "TRY002",  # create your own exception class
+  "TRY003",  # long messages outside the exception class
+]
 
-# Designate "pelican" and "pandoc_reader" as separate import sections
-known_pelican = "pelican"
-known_pandoc = "pandoc_reader"
+allowed-confusables = ["’"]
 
-sections = "FUTURE,STDLIB,THIRDPARTY,PELICAN,PANDOC,FIRSTPARTY,LOCALFOLDER"
+[tool.ruff.lint.isort]
+combine-as-imports = true
+force-sort-within-sections = true
+known-first-party = ["pelican"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"

--- a/tasks.py
+++ b/tasks.py
@@ -18,9 +18,10 @@ VENV = str(VENV_PATH.expanduser())
 BIN_DIR = "bin" if os.name != "nt" else "Scripts"
 VENV_BIN = Path(VENV) / Path(BIN_DIR)
 
-TOOLS = ("pdm", "pre-commit")
+TOOLS = ("cruft", "pdm", "pre-commit")
 PDM = which("pdm") if which("pdm") else (VENV_BIN / "pdm")
 CMD_PREFIX = f"{VENV_BIN}/" if ACTIVE_VENV else f"{PDM} run "
+CRUFT = which("cruft") if which("cruft") else f"{CMD_PREFIX}cruft"
 PRECOMMIT = which("pre-commit") if which("pre-commit") else f"{CMD_PREFIX}pre-commit"
 PTY = os.name != "nt"
 
@@ -79,6 +80,17 @@ def precommit(c):
     """Install pre-commit hooks to .git/hooks/pre-commit."""
     logger.info("** Installing pre-commit hooks **")
     c.run(f"{PRECOMMIT} install")
+
+
+@task
+def update(c, check=False):
+    """Apply upstream plugin template changes to this project."""
+    if check:
+        logger.info("** Checking for upstream template changes **")
+        c.run(f"{CRUFT} check", pty=PTY)
+    else:
+        logger.info("** Updating project from upstream template **")
+        c.run(f"{CRUFT} update", pty=PTY)
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -1,14 +1,15 @@
 from inspect import cleandoc
+import logging
 import os
 from pathlib import Path
 from shutil import which
-import sys
 
 from invoke import task
 
+logger = logging.getLogger(__name__)
+
 PKG_NAME = "pandoc_reader"
 PKG_PATH = Path(f"pelican/plugins/{PKG_NAME}")
-TOOLS = ("poetry", "pre-commit")
 
 ACTIVE_VENV = os.environ.get("VIRTUAL_ENV", None)
 VENV_HOME = Path(os.environ.get("WORKON_HOME", "~/.local/share/virtualenvs"))
@@ -16,52 +17,52 @@ VENV_PATH = Path(ACTIVE_VENV) if ACTIVE_VENV else (VENV_HOME.expanduser() / PKG_
 VENV = str(VENV_PATH.expanduser())
 BIN_DIR = "bin" if os.name != "nt" else "Scripts"
 VENV_BIN = Path(VENV) / Path(BIN_DIR)
-POETRY = which("poetry") if which("poetry") else (VENV_BIN / "poetry")
-CMD_PREFIX = f"{VENV_BIN}/" if ACTIVE_VENV else f"{POETRY} run "
+
+TOOLS = ("pdm", "pre-commit")
+PDM = which("pdm") if which("pdm") else (VENV_BIN / "pdm")
+CMD_PREFIX = f"{VENV_BIN}/" if ACTIVE_VENV else f"{PDM} run "
 PRECOMMIT = which("pre-commit") if which("pre-commit") else f"{CMD_PREFIX}pre-commit"
-PTY = True if os.name != "nt" else False
+PTY = os.name != "nt"
 
 
 @task
-def tests(c):
-    """Run the test suite."""
-    c.run(f"{CMD_PREFIX}pytest", pty=PTY)
+def tests(c, deprecations=False):
+    """Run the test suite, optionally with `--deprecations`."""
+    deprecations_flag = "" if deprecations else "-W ignore::DeprecationWarning"
+    c.run(f"{CMD_PREFIX}pytest {deprecations_flag}", pty=PTY)
 
 
 @task
-def black(c, check=False, diff=False):
-    """Run Black auto-formatter, optionally with `--check` or `--diff`."""
+def format(c, check=False, diff=False):
+    """Run Ruff's auto-formatter, optionally with `--check` or `--diff`."""
     check_flag, diff_flag = "", ""
     if check:
         check_flag = "--check"
     if diff:
         diff_flag = "--diff"
-    c.run(f"{CMD_PREFIX}black {check_flag} {diff_flag} {PKG_PATH} tasks.py")
+    c.run(
+        f"{CMD_PREFIX}ruff format {check_flag} {diff_flag} {PKG_PATH} tasks.py", pty=PTY
+    )
 
 
 @task
-def isort(c, check=False, diff=False):
-    """Ensure imports are sorted according to project standards."""
-    check_flag, diff_flag = "", ""
-    if check:
-        check_flag = "-c"
+def ruff(c, concise=False, fix=False, diff=False):
+    """Run Ruff to ensure code meets project standards."""
+    concise_flag, fix_flag, diff_flag = "", "", ""
+    if concise:
+        concise_flag = "--output-format=concise"
+    if fix:
+        fix_flag = "--fix"
     if diff:
         diff_flag = "--diff"
-    c.run(f"{CMD_PREFIX}isort {check_flag} {diff_flag} .")
+    c.run(f"{CMD_PREFIX}ruff check {concise_flag} {diff_flag} {fix_flag} .", pty=PTY)
 
 
 @task
-def flake8(c):
-    """Check code for PEP8 compliance via Flake8."""
-    c.run(f"{CMD_PREFIX}flake8 {PKG_PATH} tasks.py")
-
-
-@task
-def lint(c, diff=False):
+def lint(c, concise=False, fix=False, diff=False):
     """Check code style via linting tools."""
-    isort(c, check=True, diff=diff)
-    black(c, check=True, diff=diff)
-    flake8(c)
+    ruff(c, concise=concise, fix=fix, diff=diff)
+    format(c, check=(not fix), diff=diff)
 
 
 @task
@@ -69,34 +70,34 @@ def tools(c):
     """Install development tools in the virtual environment if not already on PATH."""
     for tool in TOOLS:
         if not which(tool):
-            print(f"** Installing {tool}.")
+            logger.info(f"** Installing {tool} **")
             c.run(f"{CMD_PREFIX}pip install {tool}")
 
 
 @task
 def precommit(c):
-    """Install pre-commit hooks to `.git/hooks/pre-commit`."""
-    print("** Installing pre-commit hooks.")
+    """Install pre-commit hooks to .git/hooks/pre-commit."""
+    logger.info("** Installing pre-commit hooks **")
     c.run(f"{PRECOMMIT} install")
 
 
 @task
 def setup(c):
     """Set up the development environment."""
-    if which("poetry") or ACTIVE_VENV:
+    if which("pdm") or ACTIVE_VENV:
         tools(c)
-        c.run(f"{CMD_PREFIX}python -m pip install --upgrade pip")
-        c.run(f"{POETRY} install")
+        c.run(f"{CMD_PREFIX}python -m pip install --upgrade pip", pty=PTY)
+        c.run(f"{PDM} update --dev", pty=PTY)
         precommit(c)
-        print("\nDevelopment environment should now be set up and ready!\n")
+        logger.info("\nDevelopment environment should now be set up and ready!\n")
     else:
         error_message = """
-            Poetry is not installed, and there is no active virtual environment available.
+            PDM is not installed, and there is no active virtual environment available.
             You can either manually create and activate a virtual environment, or you can
-            install Poetry via:
+            install PDM via:
 
-            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+            curl -sSL https://raw.githubusercontent.com/pdm-project/pdm/main/install-pdm.py | python3 -
 
             Once you have taken one of the above two steps, run `invoke setup` again.
             """  # noqa: E501
-        sys.exit(cleandoc(error_message))
+        raise SystemExit(cleandoc(error_message))

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-ignore = E203, W503


### PR DESCRIPTION
I have updated most of the other plugins under the Pelican Plugins organization to use PDM and Ruff, so I took a moment to update the Pandoc Reader plugin as well.

I also linked this plugin via Cruft to the upstream plugin template, so future template updates can be more easily [propagated to this plugin](https://github.com/getpelican/cookiecutter-pelican-plugin#updating-existing-project-via-cruft).

I had to add certain Ruff rules to the `ignore` list in order to get the linter to pass. Those rule exceptions should probably be reviewed and removed once the respective parts of the code can be adjusted to comply with those rules.